### PR TITLE
Fix ISR routine with IRAM and no switch

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,5 +14,10 @@ board = esp32dev
 framework = arduino
 build_type = debug
 monitor_filters = esp32_exception_decoder
-
-;lib_deps = https://github.com/PaulStoffregen/Encoder.git
+monitor_speed = 115200
+upload_speed = 921600
+lib_deps = 
+    me-no-dev/AsyncTCP @ ^1.1.1
+    me-no-dev/ESP Async WebServer @ ^1.2.3
+    adafruit/Adafruit NeoPixel @ ^1.10.0
+    https://github.com/PaulStoffregen/Encoder.git

--- a/src/Drive.h
+++ b/src/Drive.h
@@ -53,8 +53,8 @@ class Drive{
       void setspeed(const int velocity);
       void setspeed(const unsigned int motoNum, const int velocity);
       void setDutyMotor(const unsigned int motoNum, const int duty);
-      int32_t getEncoderValueLEFT(void);
-      int32_t getEncoderValueRIGHT(void);
+      int32_t IRAM_ATTR getEncoderValueLEFT(void);
+      int32_t IRAM_ATTR getEncoderValueRIGHT(void);
       void rpmcontrol(int rpmVorgabe);
       void updateEncoderAndRPM(unsigned long dT);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -323,7 +323,8 @@ void showLEDs(int red, int green, int blue)
 }
 
 void setup(){
-  Serial.begin(9600);
+  Serial.begin(115200);
+  delay(500);
   Serial.println("CPU Frequency in MHZ:");
   Serial.println(getCpuFrequencyMhz());
 
@@ -331,7 +332,7 @@ void setup(){
   pinMode(TOGGLEPIN1, OUTPUT);
   pinMode(TOGGLEPIN2, OUTPUT);
   timer0 = timerBegin(0, 80, true); // 12,5 ns * 80 = 1000ns = 1us
-  timerAttachInterrupt(timer0, &TimerHandler0, true);
+  timerAttachInterrupt(timer0, &TimerHandler0, /*true*/ false); //edge interrupts do not work, use false
   timerAlarmWrite(timer0, 1000, true);
   timerAlarmEnable(timer0);
 

--- a/src/myEncoder.h
+++ b/src/myEncoder.h
@@ -131,8 +131,8 @@ class myEncoder{
       /**
        * update the counter variable and reset the internal interrupt counter
       */
-       int32_t readAndResetRIGHT();
-       int32_t readAndResetLEFT();
+       int32_t IRAM_ATTR readAndResetRIGHT();
+       int32_t IRAM_ATTR readAndResetLEFT();
 
        /**
        * write a certain variable p into the internal interrupt counter


### PR DESCRIPTION
* modify `platformio.ini` to use 115200 baud (aligns with bootloader messages and makes exception decoder work), declare all library dependencies to make it actually buildable
* add `IRAM_ATTR` in all functions in the ISR's code execution path
* rewrite `update()` method to not use a `switch()` because that causes a crash (jump-table does seem to be in flash regardless)
* do not use edge interrupt (according to [this comment](https://github.com/espressif/arduino-esp32/issues/5337#issuecomment-869651250))

Output before:
```
CPU Frequency in MHZ:
240
Guru Meditation Error: Core  1 panic'ed (Cache disabled but cached memory region accessed)
Core 1 register dump:
PC      : 0x400d1274  PS      : 0x00060034  A0      : 0x40087894  A1      : 0x3ffbfec0
A2      : 0x00000000  A3      : 0x00000001  A4      : 0x000000ff  A5      : 0x4008d3a8
A6      : 0x00000000  A7      : 0x1300045c  A8      : 0x80081508  A9      : 0x3ff5f000
A10     : 0x3ffbdc90  A11     : 0x20000000  A12     : 0x00000400  A13     : 0x00000000
A14     : 0x3ffc65ec  A15     : 0xffffffff  SAR     : 0x00000016  EXCCAUSE: 0x00000007
EXCVADDR: 0x00000000  LBEG    : 0x00000000  LEND    : 0x00000000  LCOUNT  : 0x00000000
Core 1 was running in ISR context:
EPC1    : 0x40087aa5  EPC2    : 0x00000000  EPC3    : 0x00000000  EPC4    : 0x400d1274
```
Output after fix:

```
CPU Frequency in MHZ:
240

AP IP address: 192.168.4.1
HTTP server started
```